### PR TITLE
Add feature strom index selected by landfall = true

### DIFF
--- a/app/controllers/storms_controller.rb
+++ b/app/controllers/storms_controller.rb
@@ -1,6 +1,6 @@
 class StormsController < ApplicationController
   def index
-    @storms = Storm.all.reverse
+    @storms = Storm.where(landfall: true).reverse
   end
 
   def show

--- a/spec/features/storms/index_spec.rb
+++ b/spec/features/storms/index_spec.rb
@@ -6,29 +6,34 @@ RSpec.describe 'Storms Index Page' do
       @season = Season.create!(year: 2021, biggest_storm: "Ian", fema_state_emg: true)
       @storm_1 = @season.storms.create!(storm_type: "Hurricane", landfall: false, wind_spd: 155, name: "Sam")
       @storm_2 = @season.storms.create!(storm_type: "Hurricane", landfall: true, wind_spd: 154, name: "Ian")
+      @storm_3 = @season.storms.create!(storm_type: "Hurricane", landfall: true, wind_spd: 180, name: "Andrew")
       visit "/storms"
     end
 
     describe 'Then I see' do
-      it '1) Each storm in the system including its attributes' do
-        expect(page).to have_content(@storm_1.name)
-        expect(page).to have_content(@storm_1.storm_type)
-        expect(page).to have_content(@storm_1.wind_spd)
-        expect(page).to have_content('Sam did not make landfall')
+      it '1) Each storm that made landfall in the system including its attributes' do
+        expect(page).to_not have_content(@storm_1.name)
+        expect(page).to_not have_content('Sam did not make landfall')
 
         expect(page).to have_content(@storm_2.name)
         expect(page).to have_content(@storm_2.storm_type)
         expect(page).to have_content(@storm_2.wind_spd)
         expect(page).to have_content('Ian made landfall')
+
+        expect(page).to have_content(@storm_3.name)
+        expect(page).to have_content(@storm_3.storm_type)
+        expect(page).to have_content(@storm_3.wind_spd)
+        expect(page).to have_content('Ian made landfall')
       end
 
       it '2) Each storm record ordered by most recently created first (top)' do
-        expect("Hurricane #{@storm_2.name}").to appear_before("Hurricane #{@storm_1.name}")
+        save_and_open_page
+        expect("Hurricane #{@storm_3.name}").to appear_before("Hurricane #{@storm_2.name}")
       end
 
       it '3) I see when each storm was created' do
-        expect(page).to have_content("#{@storm_1.created_at}")
         expect(page).to have_content("#{@storm_2.created_at}")
+        expect(page).to have_content("#{@storm_3.created_at}")
       end
     end
   end


### PR DESCRIPTION
This PR will:
- Add feature where storms index page will only select storms that made landfall
- Testing at 99.21%. Model testing at 100.0%